### PR TITLE
Ruby 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ rvm:
   - jruby-head
   - 2.0.0
   - 2.1.2
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 

--- a/lib/asari/collection.rb
+++ b/lib/asari/collection.rb
@@ -73,6 +73,10 @@ class Asari
       ::Asari::Collection
     end
 
+    def respond_to?(method, include_all = false)
+      @data.respond_to?(method, false)
+    end
+
     def method_missing(method, *args, &block)
       @data.send(method, *args, &block)
     end

--- a/lib/asari/collection.rb
+++ b/lib/asari/collection.rb
@@ -78,7 +78,7 @@ class Asari
     end
 
     def method_missing(method, *args, &block)
-      @data.send(method, *args, &block)
+      @data.public_send(method, *args, &block)
     end
   end
 end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 
 describe Asari do
   describe Asari::Collection do
-    before :each do  
+    before :each do
       response = OpenStruct.new(:parsed_response => { "hits" => { "found" => 10, "start" => 0, "hit" => ["1","2"]}})
       @collection = Asari::Collection.new(response, 2)
     end
@@ -25,6 +25,10 @@ describe Asari do
 
     it "calculates the offset correctly" do
       expect(@collection.offset).to eq(0)
+    end
+
+    it "gracefully handles Marshaling" do
+      expect { Marshal.dump @collection }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
See @wellbredgrapefruit/asari#52 for more context.

The plan is to go ahead and just use our fork of `asari` and then update to the next version when it's released.