### PR TITLE
allow compound boolean queries

### DIFF
--- a/lib/asari.rb
+++ b/lib/asari.rb
@@ -207,7 +207,7 @@ class Asari
       hash.reduce("") do |memo, (key, value)|
         if %w(and or not).include?(key.to_s) && value.is_a?(Hash)
           sub_query = reduce.call(value)
-          memo += "(#{key}#{sub_query})" unless sub_query.empty?
+          memo += " (#{key}#{sub_query})" unless sub_query.empty?
         else
           if value.is_a?(Range) || value.is_a?(Integer)
             memo += " #{key}:#{value}"

--- a/lib/asari/version.rb
+++ b/lib/asari/version.rb
@@ -1,3 +1,3 @@
 class Asari
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -118,46 +118,46 @@ describe Asari do
     end
 
     it "builds a query string from a passed hash" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28and+foo%3A%27bar%27+baz%3A%27bug%27%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28and+foo%3A%27bar%27+baz%3A%27bug%27%29&size=10")
       @asari.search(filter: { and: { foo: "bar", baz: "bug" }})
     end
 
     it "honors the logic types" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28or+foo%3A%27bar%27+baz%3A%27bug%27%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28or+foo%3A%27bar%27+baz%3A%27bug%27%29&size=10")
       @asari.search(filter: { or: { foo: "bar", baz: "bug" }})
     end
 
     it "supports nested logic" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28or+is_donut%3A%27true%27%28and+round%3A%27true%27+frosting%3A%27true%27+fried%3A%27true%27%29%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28or+is_donut%3A%27true%27+%28and+round%3A%27true%27+frosting%3A%27true%27+fried%3A%27true%27%29%29&size=10")
       @asari.search(filter: { or: { is_donut: true, and:
                             { round: true, frosting: true, fried: true }}
       })
     end
 
     it "supports ruby native numeric ranges" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28and+bottles%3A1..99+on%3A%27wall%27%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28and+bottles%3A1..99+on%3A%27wall%27%29&size=10")
       @asari.search(filter: { and: { bottles: (1..99), on: "wall"} })
     end
 
     it "it supports numeric ranges where the lower bound is open-ended" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28and+bottles%3A..99+on%3A%27wall%27%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28and+bottles%3A..99+on%3A%27wall%27%29&size=10")
       @asari.search(filter: { and: { bottles: '..99', on: "wall"} })
     end
 
     it "it supports numeric ranges where the upper bound is open-ended" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28and+bottles%3A1..+on%3A%27wall%27%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28and+bottles%3A1..+on%3A%27wall%27%29&size=10")
       @asari.search(filter: { and: { bottles: '1..', on: "wall"} })
     end
 
     it "fails gracefully with empty params" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28or+is_donut%3A%27true%27%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28or+is_donut%3A%27true%27%29&size=10")
       @asari.search(filter: { or: { is_donut: true, and:
                             { round: "", frosting: nil, fried: nil }}
       })
     end
 
     it "supports full text search and boolean searching" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=nom&bq=%28or+is_donut%3A%27true%27%28and+fried%3A%27true%27%29%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=nom&bq=+%28or+is_donut%3A%27true%27+%28and+fried%3A%27true%27%29%29&size=10")
       @asari.search("nom", filter: { or: { is_donut: true, and:
                                    { round: "", frosting: nil, fried: true }}
       })
@@ -166,7 +166,7 @@ describe Asari do
 
   describe "geography searching" do
     it "builds a proper query string" do
-      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=%28and+lat%3A2505771415..2506771417+lng%3A2358260777..2359261578%29&size=10")
+      HTTParty.should_receive(:get).with("http://search-testdomain.us-east-1.cloudsearch.amazonaws.com/2011-02-01/search?q=&bq=+%28and+lat%3A2505771415..2506771417+lng%3A2358260777..2359261578%29&size=10")
       @asari.search filter: { and: Asari::Geography.coordinate_box(meters: 5000, lat: 45.52, lng: 122.6819) }
     end
   end


### PR DESCRIPTION
We needed to be able to turn a hash like 
`filter: { and: {type_name: 'foo', not: {tags: 'mytag'}}}`
into
`(and type_name:'foo' (not tags:'mytag'))`

to handle, for instance, excluding items tagged with a particular term from a search result.

The boolean_query field was instead returning:
`(and type_name:'foo'(not tags:'mytag'))`
which caused a bad request error.

This just adds a space where needed.